### PR TITLE
Support a wider range of events to auto-comment on

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,55 @@
-module.exports = app => {
-  app.on("issues.opened", async context => {
-    const config = await context.config(`auto-comment.yml`);
-    const { issueOpened } = config || {};
+const eventTypes = {
+  issue: [
+    "assigned",
+    "unassigned",
+    "labeled",
+    "unlabeled",
+    "opened",
+    "edited",
+    "milestoned",
+    "demilestoned",
+    "closed",
+    "reopened"
+  ],
+  pull_request: [
+    "assigned",
+    "unassigned",
+    "review_requested",
+    "review_request_removed",
+    "labeled",
+    "unlabeled",
+    "opened",
+    "edited",
+    "closed",
+    "reopened"
+  ]
+};
 
-    const params = context.issue({ body: issueOpened });
-
-    // Post a comment on the issue
-    return context.github.issues.createComment(params);
+function toCamelCase(input) {
+  return input.toLowerCase().replace(/[\.|_](.)/g, function(match, group1) {
+    return group1.toUpperCase();
   });
+}
 
-  app.on("pull_request.opened", async context => {
-    const config = await context.config(`auto-comment.yml`);
-    const { pullRequestOpened } = config || {};
+module.exports = app => {
+  const scopes = Object.keys(eventTypes);
+  scopes.map(scope => {
+    const events = eventTypes[scope];
+    events.map(event => {
+      const eventName = `${scope}.${event}`;
+      app.on(eventName, async context => {
+        const config = await context.config(`auto-comment.yml`);
+        const templateKey = toCamelCase(eventName);
+        const templateData = config[templateKey];
+        if (templateData) {
+          const params = context.issue({ body: templateData });
 
-    const params = context.issue({ body: pullRequestOpened });
+          // Post a comment on the issue
+          return context.github.issues.createComment(params);
+        }
 
-    // Post a comment on the issue
-    return context.github.issues.createComment(params);
+        return false;
+      });
+    });
   });
 };

--- a/index.js
+++ b/index.js
@@ -47,8 +47,6 @@ module.exports = app => {
           // Post a comment on the issue
           return context.github.issues.createComment(params);
         }
-
-        return false;
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -37,5 +37,9 @@
     "env": [
       "jest"
     ]
+  },
+  "jest": {
+    "verbose": false,
+    "testURL": "http://localhost/"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,8 +41,8 @@ describe("your-app", () => {
   });
 
   describe("issues.opened", () => {
-    it("Reads `issuedOpened` from the `auto-comment.yml` and sends the value to github", async () => {
-      await app.receive({ event: "issues", payload: issueOpenedEvent });
+    it("Reads `issueOpened` from the `auto-comment.yml` and sends the value to github", async () => {
+      await app.receive({ event: "issue", payload: issueOpenedEvent });
 
       expect(github.issues.createComment).toHaveBeenCalledWith({
         body: "My Message",
@@ -52,15 +52,17 @@ describe("your-app", () => {
       });
     });
 
-    it("does not create a new comment if the `issuedOpened` cannot be found in the config", async () => {
-      await app.receive({ event: "issues", payload: issueOpenedEvent });
+    it("does not create a new comment if the `issueOpened` cannot be found in the config", async () => {
+      await app.receive({ event: "issue", payload: issueOpenedEvent });
 
       github = {
         repos: {
           getContent: () =>
             Promise.resolve({
               data: {
-                content: Buffer.from(`pullRequestOpened:\n  My Message`).toString("base64")
+                content: Buffer.from(
+                  `pullRequestOpened:\n  My Message`
+                ).toString("base64")
               }
             })
         },
@@ -75,7 +77,10 @@ describe("your-app", () => {
 
   describe("pullRequests.opened", () => {
     it("Reads `pullRequestOpened` from the `auto-comment.yml` and sends the value to github", async () => {
-      await app.receive({ event: "pull_request", payload: pullRequestOpenedEvent });
+      await app.receive({
+        event: "pull_request",
+        payload: pullRequestOpenedEvent
+      });
 
       expect(github.issues.createComment).toHaveBeenCalledWith({
         body: "My Message",
@@ -86,14 +91,19 @@ describe("your-app", () => {
     });
 
     it("does not create a new comment if the `pullRequestOpened` cannot be found in the config", async () => {
-      await app.receive({ event: "pull_request", payload: pullRequestOpenedEvent });
+      await app.receive({
+        event: "pull_request",
+        payload: pullRequestOpenedEvent
+      });
 
       github = {
         repos: {
           getContent: () =>
             Promise.resolve({
               data: {
-                content: Buffer.from(`issueOpened:\n  My Message`).toString("base64")
+                content: Buffer.from(`issueOpened:\n  My Message`).toString(
+                  "base64"
+                )
               }
             })
         },


### PR DESCRIPTION
Swap out the hardcoded / repeated `issue.opened` and `pull_request.opened` events and support all of the events for **issues** and **pull requests** by looping through an object defining them.

Config file uses the same **camelCase** approach to naming conventions.